### PR TITLE
EP-2: HDFS to Hive Ingestion Job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,12 @@
 
 # Log files
 *.log
+derby.log
 
-# Scala build folder
-/target/
+# Scala/sbt build folders and artifacts
+/spark-apps/target/
+/spark-apps/project/
+/spark-apps/metastore_db/
 
 # IDE and OS specific files
 .idea/

--- a/Dockerfile.spark
+++ b/Dockerfile.spark
@@ -1,21 +1,37 @@
 # Dockerfile.spark 
 
-# Use the Bitnami Spark image as a base, which already includes Java and Scala.
+# Use the Bitnami Spark image as a base
 FROM bitnami/spark:3.5
 
-# Switch to the root user to install packages.
+# Switch to the root user to install packages
 USER root
 
-# Copy our custom JAR drivers (e.g., for PostgreSQL) into a folder that Spark automatically reads.
+# --- Install sbt (Scala Build Tool) ---
+RUN apt-get update && \
+    apt-get install -y curl gnupg apt-transport-https && \
+    curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/scalasbt-release.gpg --import && \
+    chmod 644 /etc/apt/trusted.gpg.d/scalasbt-release.gpg && \
+    echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | tee /etc/apt/sources.list.d/sbt.list && \
+    apt-get update && \
+    apt-get install -y sbt && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy our custom JAR drivers
 COPY ./jars /opt/bitnami/spark/jars/
 
-# Copy the folder where our Scala application code will reside.
-COPY ./spark-apps/scala /opt/bitnami/spark/apps/
+# Copy our application source code and build file
+COPY ./spark-apps /opt/bitnami/spark/apps/
 
-# Create a 'spark' user with a proper home directory.
-# This is a best practice to prevent permission issues.
+# Change permissions to allow any user (like our 'spark' user)
+RUN chmod -R 777 /opt/bitnami/spark/apps
+
+# Create a 'spark' user with a proper home directory
 RUN groupadd --gid 1001 spark && \
     useradd --uid 1001 --gid 1001 --shell /bin/bash --create-home spark
 
-# Switch back to the 'spark' user for execution.
+# --- SET THE HOME ENVIRONMENT VARIABLE ---
+ENV HOME /home/spark
+
+# Switch back to the 'spark' user for execution
 USER spark

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,20 @@
-# docker-compose.yml 
-
 services:
-  # --- HDFS Cluster ---
+  # --- HDFS Cluster: The Data Lake ---
+  # HDFS serves as the primary storage for raw and staged data.
   namenode:
     image: bde2020/hadoop-namenode:2.0.0-hadoop3.2.1-java8
     container_name: namenode
+    hostname: namenode
     volumes:
-      - hadoop_namenode_data:/hadoop/dfs/name
-      - ./generated_data:/tmp/data_in 
+      - hadoop_namenode_data:/hadoop/dfs/name # Persists HDFS metadata
+      - ./generated_data:/tmp/data_in         # Mounts local data generator output for ingestion
+    env_file:
+      - ./hadoop-hive.env
     environment:
       - CLUSTER_NAME=test
-      - CORE_CONF_fs_defaultFS=hdfs://namenode:9000
     ports:
-      - "9870:9870"
-      - "9000:9000"
+      - "9870:9870" # HDFS NameNode Web UI
+      - "9000:9000" # HDFS RPC Port
     networks:
       - data-pipeline-network
 
@@ -23,23 +24,37 @@ services:
     depends_on:
       - namenode
     volumes:
-      - hadoop_datanode_data:/hadoop/dfs/data
+      - hadoop_datanode_data:/hadoop/dfs/data # Persists HDFS data blocks
+    env_file:
+      - ./hadoop-hive.env
     environment:
-      SERVICE_PRECONDITION: "namenode:9870"
-      CORE_CONF_fs_defaultFS: "hdfs://namenode:9000"
+      SERVICE_PRECONDITION: "namenode:9870"  # Waits for NameNode UI to be up
     networks:
       - data-pipeline-network
 
-  # --- Hive Metastore ---
+  # --- Hive Ecosystem: The Staging Layer ---
+  # Hive provides a SQL-like interface over the files stored in HDFS.
   hive-metastore-db:
     image: postgres:13-alpine
     container_name: hive-metastore-db
     volumes:
-      - hive_metastore_db_data:/var/lib/postgresql/data
+      - hive_metastore_db_data:/var/lib/postgresql/data # Persists the Hive metadata
     environment:
       - POSTGRES_DB=metastore
       - POSTGRES_USER=hive
       - POSTGRES_PASSWORD=hive
+    networks:
+      - data-pipeline-network
+  
+  hive-metastore:
+    image: bde2020/hive:2.3.2-postgresql-metastore
+    container_name: hive-metastore
+    depends_on:
+      - hive-metastore-db
+      - namenode
+    env_file:
+      - ./hadoop-hive.env    # Loads all Hive configurations from an external file
+    command: /opt/hive/bin/hive --service metastore    # Runs this service as a Metastore
     networks:
       - data-pipeline-network
 
@@ -47,32 +62,28 @@ services:
     image: bde2020/hive:2.3.2-postgresql-metastore
     container_name: hive-server
     depends_on:
-      - hive-metastore-db
-      - namenode
-      - datanode
-    environment:
-      - HIVE_CORE_CONF_javax_jdo_option_ConnectionURL=jdbc:postgresql://hive-metastore-db/metastore
-      - HIVE_CORE_CONF_javax_jdo_option_ConnectionDriverName=org.postgresql.Driver
-      - HIVE_CORE_CONF_javax_jdo_option_ConnectionUserName=hive
-      - HIVE_CORE_CONF_javax_jdo_option_ConnectionPassword=hive
-      - HIVE_CORE_CONF_hive_metastore_uris=thrift://hive-server:9083 # Note: Hive Server refers to itself for the metastore URI
+      - hive-metastore
+    env_file:
+      - ./hadoop-hive.env
     ports:
-      - "10000:10000"
+      - "10000:10000"  # Exposes the JDBC port for clients like Spark
     networks:
       - data-pipeline-network
 
-  # --- Spark Cluster ---
+  # --- Spark Cluster: The Processing Engine ---
   spark-master:
     build:
       context: .
       dockerfile: Dockerfile.spark
     image: my-scala-spark-image:latest
     container_name: spark-master
+    env_file:
+      - ./hadoop-hive.env
     ports:
-      - "8081:8080"
-      - "7077:7077"
-    volumes:
-      - ./spark-apps/scala:/opt/bitnami/spark/apps
+      - "8081:8080"  # Spark Master Web UI
+      - "7077:7077"  # Spark Master RPC Port
+    volumes: 
+      - ./spark-apps:/opt/bitnami/spark/apps
     networks:
       - data-pipeline-network
 
@@ -84,15 +95,17 @@ services:
     container_name: spark-worker
     depends_on:
       - spark-master
+    env_file:
+      - ./hadoop-hive.env
     environment:
       - SPARK_MODE=worker
       - SPARK_MASTER_URL=spark://spark-master:7077
     volumes:
-      - ./spark-apps/scala:/opt/bitnami/spark/apps
+      - ./spark-apps:/opt/bitnami/spark/apps
     networks:
       - data-pipeline-network
   
-  # --- Data Warehouse & BI ---
+   # --- Data Warehouse & BI Layer ---
   postgres-warehouse:
     image: postgres:13-alpine
     container_name: postgres-warehouse
@@ -103,7 +116,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_DB=${POSTGRES_DB}
     volumes:
-      - postgres_data_p2:/var/lib/postgresql/data
+      - postgres_data_p2:/var/lib/postgresql/data  # Persists the final DWH tables
     networks:
       - data-pipeline-network
       
@@ -115,7 +128,7 @@ services:
     depends_on:
       - postgres-warehouse
     volumes: 
-      - metabase_data_p2:/var/lib/postgresql/data
+      - metabase_data_p2:/var/lib/postgresql/data  # Persists Metabase application data
     networks:
       - data-pipeline-network
 
@@ -124,13 +137,14 @@ services:
     image: jenkins/jenkins:lts-jdk11
     container_name: jenkins
     ports:
-      - "8080:8080"
-      - "50000:50000"
+      - "8080:8080"  # Jenkins Web UI
+      - "50000:50000"  # Port for Jenkins agents
     volumes:
-      - jenkins_data:/var/jenkins_home
+      - jenkins_data:/var/jenkins_home  # Persists Jenkins configuration and jobs
     networks:
       - data-pipeline-network
 
+# Named volumes for persistent storage
 volumes:
   hadoop_namenode_data:
   hadoop_datanode_data:
@@ -139,6 +153,7 @@ volumes:
   metabase_data_p2:
   jenkins_data:
 
+# A single bridge network for all services to communicate
 networks:
   data-pipeline-network:
     driver: bridge

--- a/hadoop-hive.env
+++ b/hadoop-hive.env
@@ -1,0 +1,18 @@
+# Hadoop & Hive Environment Configuration
+
+# --- Hive Metastore Database Connection ---
+HIVE_SITE_CONF_javax_jdo_option_ConnectionURL=jdbc:postgresql://hive-metastore-db/metastore
+HIVE_SITE_CONF_javax_jdo_option_ConnectionDriverName=org.postgresql.Driver
+HIVE_SITE_CONF_javax_jdo_option_ConnectionUserName=hive
+HIVE_SITE_CONF_javax_jdo_option_ConnectionPassword=hive
+
+# --- Hive Metastore Server Location ---
+HIVE_SITE_CONF_hive_metastore_uris=thrift://hive-metastore:9083  # Explicitly tells HiveServer2 where to find the Metastore
+
+# --- HDFS Configuration ---
+# This tells all clients (Spark, Hive, etc.) the correct NameNode RPC address.
+# Using port 9000 for Hadoop 3.
+CORE_CONF_fs_defaultFS=hdfs://namenode:9000 # Sets the default HDFS RPC address
+
+# Disable permission checks for the development environment
+HDFS_CONF_dfs_permissions_enabled=false # Disables permissions for the dev environment

--- a/spark-apps/build.sbt
+++ b/spark-apps/build.sbt
@@ -1,0 +1,17 @@
+// Project metadata
+name := "ecommerce-pipeline-spark-jobs"
+version := "1.0"
+
+// Define the Scala version. This must match the version Spark was compiled with.
+scalaVersion := "2.12.15"
+
+// Define library dependencies needed for the project to compile.
+libraryDependencies ++= Seq(
+  // Spark Core, SQL, and Hive libraries.
+  // The "% 'provided'" part is crucial: it tells sbt NOT to include these JARs
+  // in our final package, because they already exist on the Spark cluster.
+  // This keeps our final JAR file small and clean.
+  "org.apache.spark" %% "spark-core" % "3.5.0" % "provided",
+  "org.apache.spark" %% "spark-sql" % "3.5.0" % "provided",
+  "org.apache.spark" %% "spark-hive" % "3.5.0" % "provided"
+)

--- a/spark-apps/src/main/scala/ingest_transactions.scala
+++ b/spark-apps/src/main/scala/ingest_transactions.scala
@@ -9,11 +9,19 @@ object IngestTransactions {
     
     // 1. Create SparkSession with Hive support
     val spark = SparkSession.builder
+      // Set a name for the application, which will appear in the Spark UI.
       .appName("HDFS to Hive Ingestion")
-      .config("spark.sql.warehouse.dir", "/user/hive/warehouse") // Point to the Hive warehouse directory on HDFS
-      .enableHiveSupport() // Crucial for enabling Hive integration
+      // Configure the default location for Hive tables on HDFS.
+      // Both Spark and Hive properties are set for robustness.
+      .config("spark.sql.warehouse.dir", "hdfs://namenode:9000/user/hive/warehouse")
+      .config("hive.metastore.warehouse.dir", "hdfs://namenode:9000/user/hive/warehouse")
+      // Provide the URI for the external Hive Metastore service.
+      .config("hive.metastore.uris", "thrift://hive-metastore:9083")
+      // Enable integration with the Hive Metastore, allowing Spark to work with Hive tables.
+      .enableHiveSupport()
+      // Build the SparkSession, or get it if it already exists.
       .getOrCreate()
-      
+        
     println("SparkSession created with Hive support.")
 
     // 2. Define the schema for the raw text data


### PR DESCRIPTION
Resolves ticket: EP-2

**Summary:**
This Pull Request implements the first Spark/Scala application for the e-commerce data pipeline. The job is responsible for ingesting raw transaction logs from HDFS, cleaning and transforming them, and saving the result as a structured table in the Hive "Bronze" layer.

**Changes:**
* Created the `ingest_transactions.scala` application with all necessary transformation logic.
* Updated the `build.sbt` file to support the new application.
* Verified that the job successfully reads from HDFS and writes to a Hive table in the correct format.