### PR TITLE
refactor: Simplify HDFS paths for transaction data

### DIFF
--- a/spark-apps/src/main/scala/ingest_transactions.scala
+++ b/spark-apps/src/main/scala/ingest_transactions.scala
@@ -36,7 +36,7 @@ object IngestTransactions {
       
     // 3. Read data from HDFS
     // The path points to the directory where our data generator places the files.
-    val rawDataPath = "hdfs://namenode:9000/user/spark/raw_transactions/data_in"
+    val rawDataPath = "hdfs://namenode:9000/user/spark/raw_transactions"
     
     val df_raw = spark.read
       .option("header", "false") // Our files do not have a header row


### PR DESCRIPTION
This is a small refactoring PR to improve and simplify the HDFS directory structure for raw transaction logs.

**The Problem:**
The previous implementation used a redundant `/data_in` subdirectory (`/user/spark/raw_transactions/data_in`), which made the paths unnecessarily long and inconsistent with the dimension data paths.

**The Solution:**
This PR removes the `/data_in` subdirectory.
* **Before:** `.../raw_transactions/data_in/invoice_123.txt`
* **After:** `.../raw_transactions/invoice_123.txt`

**Changes:**
* **`Jenkinsfile`**: Updated the `hdfs dfs -put` command to upload transaction files directly into `/user/spark/raw_transactions/`.
* **`ingest_transactions.scala`**: Updated the `rawDataPath` variable to read from the new, simpler path.