### PR TITLE
EP-6: Make data_generator outputs visible on host and fix HDFS upload

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,9 +2,9 @@ pipeline {
     agent any
 
     environment {
-        HDFS_DIM_DIR  = "/user/spark/raw_dimensions"
+        HDFS_DIM_DIR   = "/user/spark/raw_dimensions"
         HDFS_TRANS_DIR = "/user/spark/raw_transactions"
-        WORKSPACE_DIR = "${env.WORKSPACE}/generated_data"
+        WORKSPACE_DIR  = "${env.WORKSPACE}/generated_data"
     }
 
     stages {
@@ -34,12 +34,12 @@ pipeline {
                     docker exec namenode hdfs dfs -mkdir -p ${HDFS_TRANS_DIR}
 
                     # Upload dimension CSV files
-                    cat ${WORKSPACE_DIR}/countries.csv | docker exec -i namenode hdfs dfs -put -f - ${HDFS_DIM_DIR}/countries.csv
-                    cat ${WORKSPACE_DIR}/product_info.csv | docker exec -i namenode hdfs dfs -put -f - ${HDFS_DIM_DIR}/product_info.csv
+                    docker exec -i namenode hdfs dfs -put -f ${WORKSPACE_DIR}/countries.csv ${HDFS_DIM_DIR}/countries.csv
+                    docker exec -i namenode hdfs dfs -put -f ${WORKSPACE_DIR}/product_info.csv ${HDFS_DIM_DIR}/product_info.csv
 
-                    # Upload all transaction TXT files
+                    # Upload all transaction TXT files (preserve filenames)
                     for f in ${WORKSPACE_DIR}/invoice_*.txt; do
-                        cat "$f" | docker exec -i namenode hdfs dfs -put -f - ${HDFS_TRANS_DIR}/
+                        docker exec -i namenode hdfs dfs -put -f "$f" ${HDFS_TRANS_DIR}/$(basename $f)
                     done
 
                     echo "--- HDFS upload complete ---"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,6 +160,7 @@ services:
       - jenkins_data:/var/jenkins_home  # Persists Jenkins configuration and jobs
       # Mount the Docker socket to allow Jenkins to run Docker commands
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./generated_data:/var/jenkins_home/workspace/ecommerce-daily-pipeline/generated_data 
     networks:
       - data-pipeline-network
 


### PR DESCRIPTION
Update Jenkinsfile & Docker Compose for HDFS upload and host visibility

- Jenkinsfile: ensure HDFS directories exist; upload dimension CSVs and transaction TXTs preserving filenames
- Docker Compose: mount ./generated_data to Jenkins container for host visibility of generated files


