### PR TITLE
EP-6: Fix Jenkinsfile: HDFS upload now handles all CSV and TXT files correctly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,17 +30,20 @@ pipeline {
 
                 echo "--- Uploading all files to HDFS ---"
                 sh '''
-                    # Create HDFS directories if they don't exist
+                    # Create HDFS directories
                     docker exec namenode hdfs dfs -mkdir -p ${HDFS_DIM_DIR}
                     docker exec namenode hdfs dfs -mkdir -p ${HDFS_TRANS_DIR}
 
-                    # Upload dimension CSV files from mounted folder
-                    docker exec -i namenode hdfs dfs -put -f ${NAMENODE_DATA}/countries.csv ${HDFS_DIM_DIR}/countries.csv
-                    docker exec -i namenode hdfs dfs -put -f ${NAMENODE_DATA}/product_info.csv ${HDFS_DIM_DIR}/product_info.csv
+                    # Upload dimension CSV files
+                    for csv_file in ${NAMENODE_DATA}/*.csv; do
+                        filename=$(basename "$csv_file")
+                        docker exec -i namenode hdfs dfs -put -f "$csv_file" ${HDFS_DIM_DIR}/"$filename"
+                    done
 
-                    # Upload transaction TXT files (preserve filenames)
-                    for f in ${NAMENODE_DATA}/invoice_*.txt; do
-                        docker exec -i namenode hdfs dfs -put -f "$f" ${HDFS_TRANS_DIR}/$(basename $f)
+                    # Upload transaction TXT files
+                    for txt_file in ${NAMENODE_DATA}/invoice_*.txt; do
+                        filename=$(basename "$txt_file")
+                        docker exec -i namenode hdfs dfs -put -f "$txt_file" ${HDFS_TRANS_DIR}/"$filename"
                     done
 
                     echo "--- HDFS upload complete ---"


### PR DESCRIPTION
Fix Jenkins pipeline HDFS upload

- Refactored HDFS upload to iterate over CSV and TXT files individually
- Removed wildcard upload causing "No such file or directory" errors